### PR TITLE
set comment text box to empty after submitting

### DIFF
--- a/caret/src/contents/render_comment_create.tsx
+++ b/caret/src/contents/render_comment_create.tsx
@@ -68,6 +68,7 @@ const CommentInputForm = () => {
             });
             console.log(resp);
             setIsMounted(false);
+            setComment(""); 
         } else {
             setCommentError("Comment cannot be empty.");
         }


### PR DESCRIPTION
Quick bug fix. after submitting a comment, set comment text box to empty.